### PR TITLE
Allow using tribe-exit after a redirect

### DIFF
--- a/Sniffs/CodeAnalysis/RedirectAndDieSniff.php
+++ b/Sniffs/CodeAnalysis/RedirectAndDieSniff.php
@@ -73,7 +73,7 @@ class TribalScents_Sniffs_CodeAnalysis_RedirectAndDieSniff implements PHP_CodeSn
 		$semicolon = $phpcsFile->findNext( T_SEMICOLON, $stackPtr );
 		$next = $tokens[ $phpcsFile->findNext( T_WHITESPACE, $semicolon + 1, NULL, TRUE ) ];
 
-		if ( T_EXIT == $next['code'] )
+		if ( T_EXIT == $next['code'] || 'tribe_exit' == $next['code'] )
 		{
 			return;
 		}//end if


### PR DESCRIPTION
Just because I'm tired of the notifications where we do this:

```
wp_redirect( esc_url_raw( $url ) );
tribe_exit();
```