### PR TITLE
fix(empty() check): Remove test for empty - no longer needed.

### DIFF
--- a/Sniffs/CodeAnalysis/EmptyIssetSniff.php
+++ b/Sniffs/CodeAnalysis/EmptyIssetSniff.php
@@ -29,7 +29,6 @@ class TribalScents_Sniffs_CodeAnalysis_EmptyIssetSniff implements PHP_CodeSniffe
 	public function register() {
 		return array(
 			T_ISSET,
-			T_EMPTY,
 		);
 	}//end register()
 
@@ -55,6 +54,6 @@ class TribalScents_Sniffs_CodeAnalysis_EmptyIssetSniff implements PHP_CodeSniffe
 			return;
 		}
 
-		$phpcsFile->addError( 'empty() and isset() must only contain variables (PHP 5.2 compatibility)', $stackPtr, 'Error', 'NonVarEmpty' );
+		$phpcsFile->addError( 'isset() must only contain variables (PHP 5.6 compatibility)', $stackPtr, 'Error', 'NonVarEmpty' );
 	}//end process()
 }//end class


### PR DESCRIPTION
Leave the `EmptyIssetSniff`, but remove the test for empty as we now require php 5.6 and it's no
longer applicable for `empty()`.

The variable-only requirement is still valid for `isset()` so keep that part.