### PR TITLE
Feature: PHP8+ support

### DIFF
--- a/TEC/ruleset.xml
+++ b/TEC/ruleset.xml
@@ -64,7 +64,7 @@
 		<exclude-pattern>src/Test.php</exclude-pattern>
 	</rule>
 
-		<!-- Detect Unused Use statements -->
+	<!-- Detect Unused Use statements -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
 		<properties>
 			<property name="searchAnnotations" value="true"/>

--- a/TEC/ruleset.xml
+++ b/TEC/ruleset.xml
@@ -9,6 +9,9 @@
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
+		<!-- https://github.com/WordPress/WordPress-Coding-Standards/issues/2374 -->
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 	</rule>
 
 	<!-- Warns about missing short descriptions in docblocks. -->

--- a/TEC/ruleset.xml
+++ b/TEC/ruleset.xml
@@ -10,6 +10,7 @@
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 		<!-- https://github.com/WordPress/WordPress-Coding-Standards/issues/2374 -->
 		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 	</rule>

--- a/TEC/ruleset.xml
+++ b/TEC/ruleset.xml
@@ -64,6 +64,26 @@
 		<exclude-pattern>src/Test.php</exclude-pattern>
 	</rule>
 
+		<!-- Detect Unused Use statements -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+		<properties>
+			<property name="searchAnnotations" value="true"/>
+		</properties>
+	</rule>
+
+	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+
+	<!-- Forbid uses of multiple traits separated by comma -->
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration" />
+	
+	<!-- Force trailing commas in arrays -->
+	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
+	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+
 	<exclude-pattern>*/tests/_support/_generated/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     "require": {
         "php": ">=5.6",
         "squizlabs/php_codesniffer": "^3.3.1",
-        "wp-coding-standards/wpcs": "^2.1"
+        "wp-coding-standards/wpcs": "^2.1 | ^3.0"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+        "dealerdirect/phpcodesniffer-composer-installer": "*",
         "phpcompatibility/php-compatibility": "^9"
     },
     "suggest": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
     },
     "scripts": {
         "install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
@@ -42,6 +42,8 @@
             "@phpcs"
         ]
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": ">=5.6",
         "squizlabs/php_codesniffer": "^3.3.1",
-        "wp-coding-standards/wpcs": "^2.1 | ^3.0"
+        "wp-coding-standards/wpcs": "^2.1 | ^3.0",
+        "slevomat/coding-standard": "^8.14"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",


### PR DESCRIPTION
Previously, there would be a vsprintf() crash if your IDE is on PHP8+ and using the wpcs old rules.

This allows wpcs/vipwpcs ^3.0 to be used in projects and updates excludes due to some rules being renamed.

Note that in `uplink-origin` where I was testing this, the only new rule I really noticed so far that I excluded was:

```xml
<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
```

I'm not sure if you want this excluded in this ruleset out of the box or not, but it wasn't detecting that previously.

I'd recommend updating one of your projects to use this branch and see if it finds new/unexpected rules you want to exclude out of the box.

Also, remember to bump your composer.json wpcs versions, if they're in there to properly test this:

```json
    "wp-coding-standards/wpcs": "^3.0",
    "automattic/vipwpcs": "^3.0",
```    

I also recommend you update your project's ruleset to set a PHP and WordPress version if not already in there, as this can enable/disable certain rules.

```xml
<ruleset>
  <!--  Update to the PHP version your production/local docker container runs on -->
  <config name="testVersion" value="7.4"/>
  <!-- php -r 'echo PHP_VERSION_ID;' -->
  <config name="php_version" value="70407"/>
    
  <!-- Rules will be enabled/disabled depending on the minimum WP version supported -->
  <config name="minimum_supported_wp_version" value="6.0.0" />
</ruleset>
```	
