### PR TITLE
Change standards internal name to StellarWP

### DIFF
--- a/StellarWP/Sniff.php
+++ b/StellarWP/Sniff.php
@@ -8,7 +8,7 @@
  * @package   PHP_CodeSniffer
  */
 
-namespace TEC;
+namespace StellarWP;
 
 use PHP_CodeSniffer\Sniffs;
 use PHP_CodeSniffer\Sniffs\Sniff as CS_Sniff;

--- a/StellarWP/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/StellarWP/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\Arrays;
+namespace StellarWP\Sniffs\Arrays;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;

--- a/StellarWP/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/StellarWP/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\Classes;
+namespace StellarWP\Sniffs\Classes;
 
 use PHP_CodeSniffer\Sniffs;
 use PHP_CodeSniffer\Files\File;
@@ -109,4 +109,3 @@ class PropertyDeclarationSniff extends Sniffs\AbstractVariableSniff
 
 
 }//end class
-

--- a/StellarWP/Sniffs/Classes/ValidClassNameSniff.php
+++ b/StellarWP/Sniffs/Classes/ValidClassNameSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\Classes;
+namespace StellarWP\Sniffs\Classes;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;

--- a/StellarWP/Sniffs/CodeAnalysis/RedirectAndDieSniff.php
+++ b/StellarWP/Sniffs/CodeAnalysis/RedirectAndDieSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\CodeAnalysis;
+namespace StellarWP\Sniffs\CodeAnalysis;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;

--- a/StellarWP/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/StellarWP/Sniffs/Methods/MethodDeclarationSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\Methods;
+namespace StellarWP\Sniffs\Methods;
 
 use PHP_CodeSniffer\Sniffs;
 use PHP_CodeSniffer\Files\File;

--- a/StellarWP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/StellarWP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\NamingConventions;
+namespace StellarWP\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Sniffs;
 use PHP_CodeSniffer\Files\File;
@@ -129,4 +129,3 @@ class ValidFunctionNameSniff extends Sniffs\AbstractScopeSniff
         }
     }//end processTokenOutsideScope()
 }//end class
-

--- a/StellarWP/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/StellarWP/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\PHP;
+namespace StellarWP\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;

--- a/StellarWP/Sniffs/PHP/EscjsFunctionSniff.php
+++ b/StellarWP/Sniffs/PHP/EscjsFunctionSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\PHP;
+namespace StellarWP\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;

--- a/StellarWP/Sniffs/PHP/IsAFunctionSniff.php
+++ b/StellarWP/Sniffs/PHP/IsAFunctionSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\PHP;
+namespace StellarWP\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;

--- a/StellarWP/Sniffs/Whitespace/LogicalNotSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/LogicalNotSpacingSniff.php
@@ -1,5 +1,5 @@
 <?php
-namespace TEC\Sniffs\Whitespace;
+namespace StellarWP\Sniffs\Whitespace;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;

--- a/StellarWP/Sniffs/XSS/EscapeOutputSniff.php
+++ b/StellarWP/Sniffs/XSS/EscapeOutputSniff.php
@@ -1,9 +1,9 @@
 <?php
-namespace TEC\Sniffs\XSS;
+namespace StellarWP\Sniffs\XSS;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use TEC\Sniff;
+use StellarWP\Sniff;
 
 /**
  * Squiz_Sniffs_XSS_EscapeOutputSniff.

--- a/StellarWP/ruleset.xml
+++ b/StellarWP/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="TEC" namespace="TEC" >
-	<description>The Events Calendar coding standards.</description>
+<ruleset name="StellarWP" namespace="StellarWP" >
+	<description>The StellarWP coding standards.</description>
 
 	<rule ref="WordPress-VIP-Go"/>
 	<rule ref="WordPress-Docs">


### PR DESCRIPTION
It still reads "TEC" which can lead to confusion and breakage.

Also updates all the namespaces to match the ruleset name.