### PR TITLE
Pass $data param as an array to addWarning()

### DIFF
--- a/StellarWP/Sniffs/XSS/EscapeOutputSniff.php
+++ b/StellarWP/Sniffs/XSS/EscapeOutputSniff.php
@@ -320,7 +320,7 @@ class EscapeOutputSniff extends Sniff
 				"Expected next thing to be an escaping function (see Codex for 'Data Validation'), not '%s'",
 				$i,
 				'OutputNotEscaped',
-				$this->tokens[ $i ]['content']
+				array( $this->tokens[ $i ]['content'] )
 			);
 		}
 


### PR DESCRIPTION
Quite a long time ago (9 years!), it appears the WP sniffs were copied over directly so to avoid a dependency. [One of those sniffs](https://github.com/stellarwp/coding-standards/blame/main/StellarWP/Sniffs/XSS/EscapeOutputSniff.php#L323) is incompatible with PHP 8 - it throws a fatal error that looks like:

```
PHP Fatal error:  Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given in /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/File.php:1084
67
Stack trace:
68
#0 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/File.php(1084): vsprintf()
69
#1 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/File.php(734): PHP_CodeSniffer\Files\File->addMessage()
70
#2 /home/runner/work/plugin-framework/plugin-framework/vendor/stellarwp/coding-standards/StellarWP/Sniffs/XSS/EscapeOutputSniff.php(323): PHP_CodeSniffer\Files\File->addWarning()
71
#3 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/File.php(518): StellarWP\Sniffs\XSS\EscapeOutputSniff->process()
72
#4 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(130): PHP_CodeSniffer\Files\File->process()
73
#5 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Runner.php(632): PHP_CodeSniffer\Files\LocalFile->process()
74
#6 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Runner.php(504): PHP_CodeSniffer\Runner->processFile()
75
#7 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Runner.php(116): PHP_CodeSniffer\Runner->run()
76
#8 /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/bin/phpcs(18): PHP_CodeSniffer\Runner->runPHPCS()
77
#9 /home/runner/work/plugin-framework/plugin-framework/vendor/bin/phpcs(119): include('...')
78
#10 {main}
79
  thrown in /home/runner/work/plugin-framework/plugin-framework/vendor/squizlabs/php_codesniffer/src/Files/File.php on line 1084
```

This change updates the incompatible code to pass the appropriate argument as an array. See https://github.com/WordPress/WordPress-Coding-Standards/commit/7cd46bed1e6a7a2af3fe24c7f4a044da3076d8f4 for the equivalent fix in the WPCS library. 