### PR TITLE
Feat - Custom sniff for checking spaces after `@since` & `@version` doc tags.

### DIFF
--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -45,6 +45,10 @@ final class DocCommentSpacingSniff implements Sniff {
 		if ( strlen( $whitespace ) > 1 ) {
 			$error = 'There should be exactly one space after the %s tag, not multiple.';
 			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'ExtraSpaces', $full_tag );
+
+			if ( $fix ) {
+				$this->fixMultipleSpaces( $phpcsFile, $stackPtr + 1 );
+			}
 		}
 	}
 
@@ -53,6 +57,12 @@ final class DocCommentSpacingSniff implements Sniff {
 
 		$phpcsFile->fixer->beginChangeset();
 		$phpcsFile->fixer->replaceToken( $stackPtr, $correctedComment );
+		$phpcsFile->fixer->endChangeset();
+	}
+
+	private function fixMultipleSpaces( File $phpcsFile, $stackPtr ) {
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->replaceToken( $stackPtr, " " );
 		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -11,10 +11,21 @@ use PHP_CodeSniffer\Files\File;
  * @package StellarWP\Sniffs\Whitespace
  */
 final class DocCommentSpacingSniff implements Sniff {
+	/**
+	 * Register the sniff.
+	 *
+	 * @return array<string>
+	 */
 	public function register() {
 		return [ T_DOC_COMMENT_TAG ];
 	}
 
+	/**
+	 * Process the doc comment.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens   = $phpcsFile->getTokens();
 		$full_tag = $tokens[ $stackPtr ]['content'];
@@ -52,6 +63,14 @@ final class DocCommentSpacingSniff implements Sniff {
 		}
 	}
 
+	/**
+	 * Fix the spacing issue in the doc comment.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 * @param string $tag     The tag name.
+	 * @param string $version The version number.
+	 */
 	private function fixSpacing( File $phpcsFile, $stackPtr, $tag, $version ) {
 		$correctedComment = sprintf( '%s %s', $tag, $version );
 
@@ -60,6 +79,12 @@ final class DocCommentSpacingSniff implements Sniff {
 		$phpcsFile->fixer->endChangeset();
 	}
 
+	/**
+	 * Fix the multiple space trails in the doc comment.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 */
 	private function fixMultipleSpaces( File $phpcsFile, $stackPtr ) {
 		$phpcsFile->fixer->beginChangeset();
 		$phpcsFile->fixer->replaceToken( $stackPtr, " " );

--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -31,6 +31,21 @@ final class DocCommentSpacingSniff implements Sniff {
 				$this->fixSpacing( $phpcsFile, $stackPtr, $tag, $version );
 			}
 		}
+
+		// Check for the extra whitespace after @since or @version.
+		$next_token = $tokens[$stackPtr+1];
+
+		if ( $next_token["type"] !== "T_DOC_COMMENT_WHITESPACE" ) {
+			return;
+		}
+
+		$whitespace = $next_token['content'];
+
+		// Check if @since or @version is followed by more than one space
+		if ( strlen( $whitespace ) > 1 ) {
+			$error = 'There should be exactly one space after the %s tag, not multiple.';
+			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ExtraSpaces', $full_tag);
+		}
 	}
 
 	private function fixSpacing(File $phpcsFile, $stackPtr, $tag, $version) {

--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace StellarWP\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Class DocCommentSpacingSniff
+ *
+ * @package StellarWP\Sniffs\Whitespace
+ */
+final class DocCommentSpacingSniff implements Sniff {
+	public function register() {
+		return [ T_DOC_COMMENT_TAG ];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens   = $phpcsFile->getTokens();
+		$full_tag = $tokens[ $stackPtr ]['content'];
+
+		// Check if @since or @version is missing space
+		if ( preg_match( '/@(?:since|version)(\S+)/', $full_tag, $matches, PREG_OFFSET_CAPTURE ) ) {
+			$error = 'There should be exactly one space after the %s tag.';
+			// split the tag from the version @since4.10 shoul
+			$version = $matches[1][0];
+			$tag     = strstr( $full_tag, $version, true );
+			$data    = [ $tag ];
+			$fix     = $phpcsFile->addFixableError( $error, $stackPtr, 'MissingSpace', $data );
+		}
+	}
+}

--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -19,14 +19,25 @@ final class DocCommentSpacingSniff implements Sniff {
 		$tokens   = $phpcsFile->getTokens();
 		$full_tag = $tokens[ $stackPtr ]['content'];
 
-		// Check if @since or @version is missing space
+		// Check if @since or @version is missing space.
 		if ( preg_match( '/@(?:since|version)(\S+)/', $full_tag, $matches, PREG_OFFSET_CAPTURE ) ) {
 			$error = 'There should be exactly one space after the %s tag.';
-			// split the tag from the version @since4.10 shoul
 			$version = $matches[1][0];
 			$tag     = strstr( $full_tag, $version, true );
 			$data    = [ $tag ];
 			$fix     = $phpcsFile->addFixableError( $error, $stackPtr, 'MissingSpace', $data );
+
+			if ( $fix ) {
+				$this->fixSpacing( $phpcsFile, $stackPtr, $tag, $version );
+			}
 		}
+	}
+
+	private function fixSpacing(File $phpcsFile, $stackPtr, $tag, $version) {
+		$correctedComment = sprintf('%s %s', $tag, $version);
+
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->replaceToken($stackPtr, $correctedComment);
+		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -15,13 +15,13 @@ final class DocCommentSpacingSniff implements Sniff {
 		return [ T_DOC_COMMENT_TAG ];
 	}
 
-	public function process(File $phpcsFile, $stackPtr) {
+	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens   = $phpcsFile->getTokens();
 		$full_tag = $tokens[ $stackPtr ]['content'];
 
 		// Check if @since or @version is missing space.
 		if ( preg_match( '/@(?:since|version)(\S+)/', $full_tag, $matches, PREG_OFFSET_CAPTURE ) ) {
-			$error = 'There should be exactly one space after the %s tag.';
+			$error   = 'There should be exactly one space after the %s tag.';
 			$version = $matches[1][0];
 			$tag     = strstr( $full_tag, $version, true );
 			$data    = [ $tag ];
@@ -33,7 +33,7 @@ final class DocCommentSpacingSniff implements Sniff {
 		}
 
 		// Check for the extra whitespace after @since or @version.
-		$next_token = $tokens[$stackPtr+1];
+		$next_token = $tokens[ $stackPtr + 1 ];
 
 		if ( $next_token["type"] !== "T_DOC_COMMENT_WHITESPACE" ) {
 			return;
@@ -44,15 +44,15 @@ final class DocCommentSpacingSniff implements Sniff {
 		// Check if @since or @version is followed by more than one space
 		if ( strlen( $whitespace ) > 1 ) {
 			$error = 'There should be exactly one space after the %s tag, not multiple.';
-			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ExtraSpaces', $full_tag);
+			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'ExtraSpaces', $full_tag );
 		}
 	}
 
-	private function fixSpacing(File $phpcsFile, $stackPtr, $tag, $version) {
-		$correctedComment = sprintf('%s %s', $tag, $version);
+	private function fixSpacing( File $phpcsFile, $stackPtr, $tag, $version ) {
+		$correctedComment = sprintf( '%s %s', $tag, $version );
 
 		$phpcsFile->fixer->beginChangeset();
-		$phpcsFile->fixer->replaceToken($stackPtr, $correctedComment);
+		$phpcsFile->fixer->replaceToken( $stackPtr, $correctedComment );
 		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/StellarWP/ruleset.xml
+++ b/StellarWP/ruleset.xml
@@ -91,6 +91,9 @@
 	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
 	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
 
+	<!-- Check for proper spacing in comment tags -->
+	<rule ref="StellarWP.Whitespace.DocCommentSpacing"/>
+
 	<!-- Don't check test-generated files. -->
 	<exclude-pattern>*/tests/_support/_generated/*</exclude-pattern>
 


### PR DESCRIPTION
* This sniff makes sure that `@since` and `@version` doc tags always have only 1 space after them.

![Screenshot 2025-02-15 at 4 34 45 AM](https://github.com/user-attachments/assets/64485aa4-66b0-4b34-bad0-2661f6df530b)
