### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ composer global require "sirbrillig/phpcs-variable-analysis:*"
 composer global require "slevomat/coding-standard:^8.14.0"
 
 # Update PHPCS installed paths to include all standards
-phpcs --config-set installed_paths "$(phpcs --config-show | grep installed_paths | awk '{ print $2 }'),${HOME}/.config/composer/vendor/phpcsstandards/phpcsextra,${HOME}/.config/composer/vendor/phpcsstandards/phpcsutils,${HOME}/.config/composer/vendor/wp-coding-standards/wpcs,${HOME}/.composer/vendor/automattic/vipwpcs,${HOME}/.composer/vendor/stellarwp/coding-standards,${HOME}/.composer/vendor/sirbrillig/phpcs-variable-analysis,${HOME}/.composer/vendor/slevomat/coding-standard"
+phpcs --config-set installed_paths "$(phpcs --config-show | grep installed_paths | awk '{ print $2 }'),${HOME}/.composer/vendor/phpcsstandards/phpcsextra,${HOME}/.composer/vendor/phpcsstandards/phpcsutils,${HOME}/.composer/vendor/wp-coding-standards/wpcs,${HOME}/.composer/vendor/automattic/vipwpcs,${HOME}/.composer/vendor/stellarwp/coding-standards,${HOME}/.composer/vendor/sirbrillig/phpcs-variable-analysis,${HOME}/.composer/vendor/slevomat/coding-standard"
 
 # Verify installation
 echo "Installed PHPCS version:"


### PR DESCRIPTION
Correct path in example script.

This drove me nuts for a hour or so - after running this script the VIP Sniffs would fatal as they could not find the installed WPCS scripts. While my paths are the "standard" the paths are not all the same in the `phpcs --config-set installed_paths` portion of the readme: some started with `.composer` and some with `.config/composer`