### PR TITLE
Fix PHP 8.0+ fatal error in DocCommentSpacingSniff

### DIFF
--- a/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
+++ b/StellarWP/Sniffs/Whitespace/DocCommentSpacingSniff.php
@@ -55,7 +55,8 @@ final class DocCommentSpacingSniff implements Sniff {
 		// Check if @since or @version is followed by more than one space
 		if ( strlen( $whitespace ) > 1 ) {
 			$error = 'There should be exactly one space after the `%s` tag, not multiple.';
-			$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'ExtraSpaces', $full_tag );
+
+			$fix = $phpcsFile->addFixableError( $error, $stackPtr, 'ExtraSpaces', [ $full_tag ] );
 
 			if ( $fix ) {
 				$this->fixMultipleSpaces( $phpcsFile, $stackPtr + 1 );


### PR DESCRIPTION
The DocCommentSpacingSniff was causing a fatal error in PHP 8.0+ due to passing a string instead of an array to vsprintf():

<img width="1542" height="271" alt="Screenshot 2025-09-19 at 15 23 16" src="https://github.com/user-attachments/assets/72f69f80-9216-430e-9837-ac2c4b6950f6" />
